### PR TITLE
Add logs

### DIFF
--- a/.github/workflows/auto-pr-review.yml
+++ b/.github/workflows/auto-pr-review.yml
@@ -6,6 +6,10 @@ on:
   pull_request_review_comment:
     types: [created]
 
+env:
+  ACTIONS_STEP_DEBUG: true
+  ACTIONS_RUNNER_DEBUG: true
+
 jobs:
   claude:
     if: |
@@ -75,3 +79,10 @@ jobs:
           # Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           use_sticky_comment: true
           track_progress: true
+
+      - name: Upload Log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-execution-output
+          path: /home/runner/work/_temp/claude-execution-output.json


### PR DESCRIPTION
Retrieving a failed signature. Action is no longer failing silently which is better than before.
