### PR TITLE
Remove max turns flag

### DIFF
--- a/.github/workflows/auto-pr-review.yml
+++ b/.github/workflows/auto-pr-review.yml
@@ -74,7 +74,6 @@ jobs:
           # safe to pass via claude_args.
           claude_args: |
             --model sonnet
-            --max-turns 2
 
           # Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           use_sticky_comment: true


### PR DESCRIPTION
Workflow throws error if max turns is reached. There is no default.
